### PR TITLE
Use .godir instead of Godeps

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,3 @@
+before:
+  - rm -rf Godeps
+  - echo "canary-agent" > .godir


### PR DESCRIPTION
So that the packaging works (https://packager.io/gh/pkgr/canary-agent/build_runs/1).